### PR TITLE
Scalability hacks

### DIFF
--- a/qml/components/Bubble.qml
+++ b/qml/components/Bubble.qml
@@ -30,21 +30,23 @@
 **********************************************************************/
 
 import QtQuick 2.1
+import Sailfish.Silica 1.0
+
 import "../js/UIConstants.js" as UIConstants
-import "../js/theme.js" as Theme
+import "../js/theme.js" as ThemeJS
 
 Rectangle {
-    height: 35
-    width: count_label.width + 15
-    radius: 12
+    height: 35 * Theme.pixelRatio
+    width: (count_label.width + 15) * Theme.pixelRatio
+    radius: 12 * Theme.pixelRatio
     smooth: true
     color: "#0d67b3"
     property int count
     Text {
         id: count_label
         text: count
-        font.pixelSize: UIConstants.FONT_LARGE * appWindow.scalingFactor
-        color: Theme.theme[appWindow.colorscheme].COLOR_FOREGROUND
+        font.pixelSize: UIConstants.FONT_LARGE * appWindow.scalingFactor * Theme.pixelRatio
+        color: ThemeJS.theme[appWindow.colorscheme].COLOR_FOREGROUND
         anchors.verticalCenter: parent.verticalCenter
         anchors.horizontalCenter: parent.horizontalCenter
     }

--- a/qml/components/FavoritesDelegate.qml
+++ b/qml/components/FavoritesDelegate.qml
@@ -42,7 +42,7 @@ ListItem {
         source: index == 0 ? "image://theme/icon-m-gps" : "image://theme/icon-m-favorite-selected"
         anchors.left: parent.left
         anchors.verticalCenter: parent.verticalCenter
-        height: 40
+        height: 40 * Theme.pixelRatio
         width: height
     }
 

--- a/qml/components/LocationEntry.qml
+++ b/qml/components/LocationEntry.qml
@@ -308,10 +308,10 @@ Column {
         }
         Text {
             id: label
-            font.pixelSize: 36
+            font.pixelSize: 36 * Theme.pixelRatio
             color: Theme.highlightColor
             lineHeightMode: Text.FixedHeight
-            lineHeight: font.pixelSize * 1.1
+            lineHeight: font.pixelSize * 1.1 * Theme.pixelRatio
             anchors.left: parent.left
         }
         Bubble {
@@ -365,9 +365,9 @@ Column {
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.verticalCenterOffset: -8
                 smooth: true
-                radius: 10
-                height: 20
-                width: 20
+                radius: 10 * Theme.pixelRatio
+                height: 20 * Theme.pixelRatio
+                width: 20 * Theme.pixelRatio
                 opacity: 0.6
             }
 

--- a/qml/components/ResultDelegate.qml
+++ b/qml/components/ResultDelegate.qml
@@ -89,7 +89,7 @@ Component {
                         id: transportIcon
                         source: "qrc:/images/" + type + ".png"
                         smooth: true
-                        height: 50
+                        height: 50 * Theme.pixelRatio
                         width: height
                     }
 

--- a/qml/components/SwitchLocation.qml
+++ b/qml/components/SwitchLocation.qml
@@ -56,7 +56,7 @@ Item {
         anchors.centerIn: parent
         source: "image://theme/icon-m-shuffle"
         smooth: true
-        height: 50
+        height: 50 * Theme.pixelRatio
         mirror: false
         width: height
     }

--- a/qml/components/TimeSwitch.qml
+++ b/qml/components/TimeSwitch.qml
@@ -37,7 +37,7 @@ Item {
     property bool timeNow: true
     property bool dateToday: dateButton.dateToday
     width: parent.width
-    height: 50
+    height: 50 * Theme.pixelRatio
     anchors.left: parent.left
 
     function setTimeNow() {
@@ -69,7 +69,8 @@ Item {
         id: nowSwitch
         anchors.left: parent.left
         anchors.verticalCenter: parent.verticalCenter
-        width: 178
+        // width: 178
+        width: mainPage.width * 0.33
         text: qsTr("Now")
         checked: true
         automaticCheck: false
@@ -99,7 +100,7 @@ Item {
                                                               myTime.getMinutes()? myTime.getMinutes() : 0)
             }
         }
-        Spacing { id: dateButtonSpacing; anchors.left: dateButton.right; width: 10 }
+        Spacing { id: dateButtonSpacing; anchors.left: dateButton.right; width: 10 * Theme.pixelRatio }
         TimeButton {
             id: timeButton
             anchors.left: dateButtonSpacing.right

--- a/qml/pages/MainPage.qml
+++ b/qml/pages/MainPage.qml
@@ -282,7 +282,7 @@ Page {
 
                 SwitchLocation {
                     anchors.top: from.top
-                    anchors.topMargin: 113  // Hack to place switch a bit over both from and to LocationEntries
+                    anchors.topMargin: from.height - location_spacing.height - UIConstants.DEFAULT_MARGIN // Hack to place switch between `from` and `to` LocationEntries
                     z: 1
                     from: from
                     to: to
@@ -302,11 +302,11 @@ Page {
             TimeTypeSwitch {
                 id: timeTypeSwitch
             }
-            Spacing { height: 5 }
+            Spacing { height: 5 * Theme.pixelRatio }
             TimeSwitch {
                 id: timeSwitch
             }
-            Spacing { height: 5 }
+            Spacing { height: 5 * Theme.pixelRatio }
 
             Button {
                 visible: !searchButtonDisabled
@@ -321,7 +321,7 @@ Page {
             }
         }
 
-        Spacing { id: favorites_spacing; anchors.top: content_column.bottom; height: 5 }
+        Spacing { id: favorites_spacing; anchors.top: content_column.bottom; height: 5 * Theme.pixelRatio }
 
 
         Item {
@@ -331,11 +331,11 @@ Page {
             anchors.leftMargin: Theme.paddingSmall
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.top: favorites_spacing.bottom
-            height: favoriteRouteHeader.height + UIConstants.DEFAULT_MARGIN
+            height: (favoriteRouteHeader.height + UIConstants.DEFAULT_MARGIN) * Theme.pixelRatio
             Text {
                 id: favoriteRouteHeader
                 color: Theme.highlightColor
-                font.pixelSize: 36
+                font.pixelSize: 36 * Theme.pixelRatio
                 text: qsTr("Favorite routes")
             }
         }
@@ -344,7 +344,7 @@ Page {
             id: favoriteRouteList
             anchors.top: headeritem.bottom
             anchors.bottom: parent.bottom
-            spacing: 5
+            spacing: 5 * Theme.pixelRatio
             width: parent.width
             model: favoriteRoutesModel
             delegate: favoriteRouteManageDelegate
@@ -352,7 +352,8 @@ Page {
 
             ViewPlaceholder {
                 enabled: favoriteRouteList.count == 0
-                verticalOffset: -300
+                // Not perfect, but shows the text on Jolla Phone, Jolla Tablet and Fairphone2 (was -300)
+                verticalOffset: (favoriteRouteList.height - mainPage.height) * 0.5
                 text: qsTr("No saved favorite routes")
             }
 

--- a/qml/pages/ResultPage.qml
+++ b/qml/pages/ResultPage.qml
@@ -122,7 +122,7 @@ Page {
         model: routeModel
         footer: footer
         delegate: ResultDelegate {}
-        spacing: 10
+        spacing: 10 * Theme.pixelRatio
         interactive: !busyIndicator.running
         header: Column {
             width: parent.width


### PR DESCRIPTION
Hi!

Figured I could take a stab at making the app work better on the Fairphone2 and build it for the tablet, because the scaling was off and I couldn't find an x86 build anyway.

This is not 100% perfect on the tablet but seems more than serviceable on the Fairphone2 and practically indistinguishable on the Jolla Phone.

Mainly consists of adding some `* Theme.pixelRatio` multipliers to static widths, but also tried to get rid of some non-portable magic numbers.

What do you think? I'd appreciate a merge, because this seems to work fine :)

#8 related.
