### PR TITLE
Support for Waltti regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 JollaOpas
 =========
 
-Journey planner for Helsinki, Tampere & Turku area - fork of [Jopas](https://github.com/rasjani/Jopas) originally forked from [Meegopas](https://github.com/junousia/Meegopas) for SailfishOS. Routing information is based on open data API:s provided by [Helsinki Regional Transport Authority](http://developer.reittiopas.fi/pages/en/http-get-interface-version-2.php) and [City of Tampere](http://developer.publictransport.tampere.fi/pages/en/http-get-interface.php).
+Journey planner for Finnish mass transit regions using the Digitransit API. Fork of [Jopas](https://github.com/rasjani/Jopas) originally forked from [Meegopas](https://github.com/junousia/Meegopas) for SailfishOS. Routing information is based on open data API:s provided by [Helsinki Regional Transport Authority](http://developer.reittiopas.fi/pages/en/http-get-interface-version-2.php) and [City of Tampere](http://developer.publictransport.tampere.fi/pages/en/http-get-interface.php).
 
 Installing
 ----------

--- a/qml/components/LocationEntry.qml
+++ b/qml/components/LocationEntry.qml
@@ -275,7 +275,7 @@ Column {
         triggeredOnStart: false
         onTriggered: {
             if(textfield.acceptableInput) {
-                Reittiopas.get_geocode(textfield.text, suggestionModel, Storage.getSetting('api'))
+                Reittiopas.get_geocode(textfield.text, suggestionModel, regions.getRegion())
             }
         }
     }

--- a/qml/components/MapElement.qml
+++ b/qml/components/MapElement.qml
@@ -176,10 +176,7 @@ Item {
         interval: appWindow.currentApi !== "helsinki" ? 3000 : 300
         repeat: appWindow.currentApi !== "helsinki"
         onTriggered: {
-            if (appWindow.currentApi !== "helsinki") {
-                receiveVehicleLocation()
-            }
-            else {
+            if (appWindow.currentApi === "helsinki") {
                 mqttClient.port = "8883"
                 mqttClient.connectToHost()
                 for (var allowedLine in vehicleModel.vehicleCodesToShowOnMap) {
@@ -189,6 +186,9 @@ Item {
                     vehicleToSubscribe.messageReceived.connect(addMqttVehicle)
                     mqttSubscriptionMap.push(vehicleToSubscribe)
                 }
+            }
+            else {
+                receiveVehicleLocation()
             }
         }
     }
@@ -451,7 +451,9 @@ Item {
     function initialize(multipleRoutes) {
         flickable_map.addMapItem(current_position)
 
-        vehicleUpdateTimer.start()
+        if (appWindow.currentApi === "helsinki" || appWindow.currentApi === "turku" || appWindow.currentApi === "tampere") {
+            vehicleUpdateTimer.start()
+        }
 
         Helper.clear_objects()
         vehicleModel.vehicleCodesToShowOnMap = []

--- a/qml/js/reittiopas.js
+++ b/qml/js/reittiopas.js
@@ -132,10 +132,14 @@ function get_route(parameters, itineraries_model, itineraries_json, region) {
     var query = '{plan(from:{lat:' + graphqlFromLat + ',lon:' + graphqlFromLon + '},to:{lat:'
             + graphqlToLat + ',lon:' + graphqlToLon + '},date:"' + graphqlDate + '",time:"'
             + graphqlTime + '",numItineraries:' + graphqlNumberOfItinaries
-            + ',modes:"' + parameters.modes + '",minTransferTime:'
-            + graphqlTransferTime + ',walkBoardCost:' + graphqlWalkBoardCost + ',walkReluctance:'
-            + graphqlWalkReluctance + ',walkSpeed:' + graphqlWalkSpeed + graphqlArriveBy
-            + '){itineraries{walkDistance,duration,startTime,endTime,legs{mode route{shortName gtfsId} duration startTime endTime from{lat lon name stop{code name}},intermediateStops{lat lon code name},to{lat lon name stop{code name}},distance, legGeometry{points}}}}}';
+            + ',minTransferTime:' + graphqlTransferTime + ',walkBoardCost:'
+            + graphqlWalkBoardCost + ',walkReluctance:' + graphqlWalkReluctance
+            + ',walkSpeed:' + graphqlWalkSpeed;
+    // Show all results for the Finland region.
+    if (region.identifier !== "finland") {
+        query = query + ',modes:"' + parameters.modes + '"';
+    }
+    query = query + graphqlArriveBy + '){itineraries{walkDistance,duration,startTime,endTime,legs{mode route{shortName gtfsId} duration startTime endTime from{lat lon name stop{code name}},intermediateStops{lat lon code name},to{lat lon name stop{code name}},distance, legGeometry{points}}}}}';
 
 //    console.debug(query);
     var http_request = new XMLHttpRequest();

--- a/qml/js/reittiopas.js
+++ b/qml/js/reittiopas.js
@@ -55,6 +55,10 @@ function get_geocode(term, model, api_type) {
         boundarycirclelat = 60.451;
         boundarycirclelon = 22.267;
     }
+    else if (api_type ==='hameenlinna') {
+        boundarycirclelat = 60.997;
+        boundarycirclelon = 24.465;
+    }
 
     var query = "boundary.circle.lat=" + boundarycirclelat + "&boundary.circle.lon=" + boundarycirclelon
             + "&boundary.circle.radius=" + boundarycircleradius + "&size=" + size + "&text=" + term;
@@ -125,6 +129,9 @@ function get_route(parameters, itineraries_model, itineraries_json, api_type) {
     var queryType = 'routing/v1/routers/hsl/index/graphql';
     if (api_type === 'tampere' || api_type === 'turku') {
         queryType = 'routing/v1/routers/finland/index/graphql';
+    }
+    if (api_type === 'hameenlinna') {
+        queryType = 'routing/v1/routers/waltti/index/graphql';
     }
 
 //    console.debug(JSON.stringify(parameters));

--- a/qml/js/reittiopas.js
+++ b/qml/js/reittiopas.js
@@ -38,34 +38,20 @@ API['digitransitgeocoding'].URL = 'https://api.digitransit.fi/'
 /****************************************************************************************************/
 /*                     address to location                                                          */
 /****************************************************************************************************/
-function get_geocode(term, model, api_type) {
+function get_geocode(term, model, region) {
     model.done = false;
-    api_type = api_type || 'helsinki';
     var size = 10;
     var queryType = 'geocoding/v1/search';
-    var boundarycircleradius = 40;
-    // Search only on 40km radius from Helsinki railway station or Tampere Keskustori
-    var boundarycirclelat = 60.169;
-    var boundarycirclelon = 24.940;
-    if (api_type === 'tampere') {
-        boundarycirclelat = 61.498;
-        boundarycirclelon = 23.759;
-    }
-    else if (api_type ==='turku') {
-        boundarycirclelat = 60.451;
-        boundarycirclelon = 22.267;
-    }
-    else if (api_type ==='hameenlinna') {
-        boundarycirclelat = 60.997;
-        boundarycirclelon = 24.465;
+    var query = "size=" + size + "&text=" + term;
+    if (region.boundarycirclelat && region.boundarycirclelon) {
+        query = query + "&boundary.circle.lat=" + region.boundarycirclelat + "&boundary.circle.lon=" + region.boundarycirclelon
+                    + "&boundary.circle.radius=" + 40;
     }
 
-    var query = "boundary.circle.lat=" + boundarycirclelat + "&boundary.circle.lon=" + boundarycirclelon
-            + "&boundary.circle.radius=" + boundarycircleradius + "&size=" + size + "&text=" + term;
-
-//    console.debug(API['digitransitgeocoding'].URL + queryType + '?' + query);
     var http_request = new XMLHttpRequest();
-    http_request.open("GET", API['digitransitgeocoding'].URL + queryType + '?' + query);
+    var url = API['digitransitgeocoding'].URL + queryType + '?' + query;
+//    console.debug(url);
+    http_request.open("GET", url);
     http_request.onreadystatechange = function() {
         if (http_request.readyState === XMLHttpRequest.DONE) {
             var a = JSON.parse(http_request.responseText);
@@ -122,17 +108,10 @@ function get_reverse_geocode(latitude, longitude, model, api_type) {
 /****************************************************************************************************/
 /*                     Reittiopas query class                                                       */
 /****************************************************************************************************/
-function get_route(parameters, itineraries_model, itineraries_json, api_type) {
+function get_route(parameters, itineraries_model, itineraries_json, region) {
     itineraries_model.done = false;
-    api_type = api_type || 'helsinki';
     var size = 5;
-    var queryType = 'routing/v1/routers/hsl/index/graphql';
-    if (api_type === 'tampere' || api_type === 'turku') {
-        queryType = 'routing/v1/routers/finland/index/graphql';
-    }
-    if (api_type === 'hameenlinna') {
-        queryType = 'routing/v1/routers/waltti/index/graphql';
-    }
+    var queryType = 'routing/v1/routers/' + region.apiName + '/index/graphql';
 
 //    console.debug(JSON.stringify(parameters));
     var graphqlFromLon = parameters.from.split(',', 2)[0]

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -48,28 +48,28 @@ ApplicationWindow {
             apiName: "finland"
         }
         ListElement {
-            name: QT_TR_NOOP("Helsinki ja pääkaupunkiseutu (HSL)")
+            name: QT_TR_NOOP("Helsinki and the capital region (HRT)")
             identifier: "helsinki"
             apiName: "hsl"
             boundarycirclelat: 60.169
             boundarycirclelon: 24.940
         }
         ListElement {
-            name: QT_TR_NOOP("Tampereen alue (Nysse)")
+            name: QT_TR_NOOP("Tampere region (Nysse)")
             identifier: "tampere"
             apiName: "finland"
             boundarycirclelat: 61.498
             boundarycirclelon: 23.759
         }
         ListElement {
-            name: QT_TR_NOOP("Turun alue (Föli)")
+            name: QT_TR_NOOP("Turku region (Föli)")
             identifier: "turku"
             apiName: "finland"
             boundarycirclelat: 60.451
             boundarycirclelon: 22.267
         }
         ListElement {
-            name: QT_TR_NOOP("Hämeenlinnan seutu")
+            name: QT_TR_NOOP("Hämeenlinna region")
             identifier: "hameenlinna"
             apiName: "waltti"
             boundarycirclelat: 60.997
@@ -83,28 +83,28 @@ ApplicationWindow {
             boundarycirclelon: 27.190
         }
         ListElement {
-            name: QT_TR_NOOP("Joensuun seutu (JOJO)")
+            name: QT_TR_NOOP("Joensuu region (JOJO)")
             identifier: "joensuu"
             apiName: "waltti"
             boundarycirclelat: 62.601
             boundarycirclelon: 29.762
         }
         ListElement {
-            name: QT_TR_NOOP("Jyväskylän seutu (Linkki)")
+            name: QT_TR_NOOP("Jyväskylä region (Linkki)")
             identifier: "jyvaskyla"
             apiName: "waltti"
             boundarycirclelat: 62.243
             boundarycirclelon: 25.747
         }
         ListElement {
-            name: QT_TR_NOOP("Kajaanin seutu")
+            name: QT_TR_NOOP("Kajaani region")
             identifier: "kajaani"
             apiName: "waltti"
             boundarycirclelat: 64.227
             boundarycirclelon: 27.729
         }
         ListElement {
-            name: QT_TR_NOOP("Kotkan seutu")
+            name: QT_TR_NOOP("Kotka region")
             identifier: "kotka"
             apiName: "waltti"
             boundarycirclelat: 60.461
@@ -118,14 +118,14 @@ ApplicationWindow {
             boundarycirclelon: 26.700
         }
         ListElement {
-            name: QT_TR_NOOP("Kuopion seutu (Vilkku)")
+            name: QT_TR_NOOP("Kuopio region (Vilkku)")
             identifier: "kuopio"
             apiName: "waltti"
             boundarycirclelat: 62.892
             boundarycirclelon: 27.678
         }
         ListElement {
-            name: QT_TR_NOOP("Lahden seutu (LSL)")
+            name: QT_TR_NOOP("Lahti region (LSL)")
             identifier: "lahti"
             apiName: "waltti"
             boundarycirclelat: 60.984
@@ -146,7 +146,7 @@ ApplicationWindow {
             boundarycirclelon: 27.274
         }
         ListElement {
-            name: QT_TR_NOOP("Oulun seutu")
+            name: QT_TR_NOOP("Oulu region")
             identifier: "oulu"
             apiName: "waltti"
             boundarycirclelat: 65.012

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -40,6 +40,126 @@ ApplicationWindow {
 
     cover: Qt.resolvedUrl("pages/CoverPage.qml")
 
+    ListModel {
+        id: regions
+
+        ListElement {
+            text: QT_TR_NOOP("Finland")
+            apiName: "finland"
+        }
+        ListElement {
+            text: QT_TR_NOOP("Helsinki")
+            apiName: "hsl"
+            boundarycirclelat: 60.169
+            boundarycirclelon: 24.940
+        }
+        ListElement {
+            text: QT_TR_NOOP("Tampere")
+            apiName: "finland"
+            boundarycirclelat: 61.498
+            boundarycirclelon: 23.759
+        }
+        ListElement {
+            text: QT_TR_NOOP("Turku")
+            apiName: "finland"
+            boundarycirclelat: 60.451
+            boundarycirclelon: 22.267
+        }
+        ListElement {
+            text: QT_TR_NOOP("Hämeenlinna")
+            apiName: "waltti"
+            boundarycirclelat: 60.997
+            boundarycirclelon: 24.465
+        }
+        ListElement {
+            text: QT_TR_NOOP("Joensuu")
+            apiName: "waltti"
+            boundarycirclelat: 62.601
+            boundarycirclelon: 29.762
+        }
+        ListElement {
+            text: QT_TR_NOOP("Jyväskylä")
+            apiName: "waltti"
+            boundarycirclelat: 62.243
+            boundarycirclelon: 25.747
+        }
+        ListElement {
+            text: QT_TR_NOOP("Kajaani")
+            apiName: "waltti"
+            boundarycirclelat: 64.227
+            boundarycirclelon: 27.729
+        }
+        ListElement {
+            text: QT_TR_NOOP("Kotka")
+            apiName: "waltti"
+            boundarycirclelat: 60.461
+            boundarycirclelon: 26.939
+        }
+        ListElement {
+            text: QT_TR_NOOP("Kouvola")
+            apiName: "waltti"
+            boundarycirclelat: 60.869
+            boundarycirclelon: 26.700
+        }
+        ListElement {
+            text: QT_TR_NOOP("Kuopio")
+            apiName: "waltti"
+            boundarycirclelat: 62.892
+            boundarycirclelon: 27.678
+        }
+        ListElement {
+            text: QT_TR_NOOP("Lahti")
+            apiName: "waltti"
+            boundarycirclelat: 60.984
+            boundarycirclelon: 25.656
+        }
+        ListElement {
+            text: QT_TR_NOOP("Lappeenranta")
+            apiName: "waltti"
+            boundarycirclelat: 61.056
+            boundarycirclelon: 28.185
+        }
+        ListElement {
+            text: QT_TR_NOOP("Mikkeli")
+            apiName: "waltti"
+            boundarycirclelat: 61.688
+            boundarycirclelon: 27.274
+        }
+        ListElement {
+            text: QT_TR_NOOP("Oulu")
+            apiName: "waltti"
+            boundarycirclelat: 65.012
+            boundarycirclelon: 25.471
+        }
+        ListElement {
+            text: QT_TR_NOOP("Rovaniemi")
+            apiName: "waltti"
+            boundarycirclelat: 66.500
+            boundarycirclelon: 25.714
+        }
+        ListElement {
+            text: QT_TR_NOOP("Salo")
+            apiName: "waltti"
+            boundarycirclelat: 60.385
+            boundarycirclelon: 23.129
+        }
+        ListElement {
+            text: QT_TR_NOOP("Vaasa")
+            apiName: "waltti"
+            boundarycirclelat: 63.096
+            boundarycirclelon: 21.616
+        }
+
+        function getRegion() {
+            var apiName = Storage.getSetting('api');
+            for (var i = 0; i < regions.count; i++) {
+                var value = regions.get(i);
+                if (apiName === value.text.toLowerCase()) {
+                    return value;
+                }
+            }
+        }
+    }
 
     InfoBanner {
         id: infoBanner

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -72,6 +72,12 @@ ApplicationWindow {
             boundarycirclelon: 24.465
         }
         ListElement {
+            text: QT_TR_NOOP("Iisalmi")
+            apiName: "waltti"
+            boundarycirclelat: 63.557
+            boundarycirclelon: 27.190
+        }
+        ListElement {
             text: QT_TR_NOOP("Joensuu")
             apiName: "waltti"
             boundarycirclelat: 62.601
@@ -136,12 +142,6 @@ ApplicationWindow {
             apiName: "waltti"
             boundarycirclelat: 66.500
             boundarycirclelon: 25.714
-        }
-        ListElement {
-            text: QT_TR_NOOP("Salo")
-            apiName: "waltti"
-            boundarycirclelat: 60.385
-            boundarycirclelon: 23.129
         }
         ListElement {
             text: QT_TR_NOOP("Vaasa")

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -44,107 +44,124 @@ ApplicationWindow {
         id: regions
 
         ListElement {
-            text: QT_TR_NOOP("Finland")
+            name: QT_TR_NOOP("Finland")
             apiName: "finland"
         }
         ListElement {
-            text: QT_TR_NOOP("Helsinki")
+            name: QT_TR_NOOP("Helsinki ja pääkaupunkiseutu (HSL)")
+            identifier: "helsinki"
             apiName: "hsl"
             boundarycirclelat: 60.169
             boundarycirclelon: 24.940
         }
         ListElement {
-            text: QT_TR_NOOP("Tampere")
+            name: QT_TR_NOOP("Tampereen alue (Nysse)")
+            identifier: "tampere"
             apiName: "finland"
             boundarycirclelat: 61.498
             boundarycirclelon: 23.759
         }
         ListElement {
-            text: QT_TR_NOOP("Turku")
+            name: QT_TR_NOOP("Turun alue (Föli)")
+            identifier: "turku"
             apiName: "finland"
             boundarycirclelat: 60.451
             boundarycirclelon: 22.267
         }
         ListElement {
-            text: QT_TR_NOOP("Hämeenlinna")
+            name: QT_TR_NOOP("Hämeenlinnan seutu")
+            identifier: "hameenlinna"
             apiName: "waltti"
             boundarycirclelat: 60.997
             boundarycirclelon: 24.465
         }
         ListElement {
-            text: QT_TR_NOOP("Iisalmi")
+            name: QT_TR_NOOP("Iisalmi")
+            identifier: "iisalmi"
             apiName: "waltti"
             boundarycirclelat: 63.557
             boundarycirclelon: 27.190
         }
         ListElement {
-            text: QT_TR_NOOP("Joensuu")
+            name: QT_TR_NOOP("Joensuun seutu (JOJO)")
+            identifier: "joensuu"
             apiName: "waltti"
             boundarycirclelat: 62.601
             boundarycirclelon: 29.762
         }
         ListElement {
-            text: QT_TR_NOOP("Jyväskylä")
+            name: QT_TR_NOOP("Jyväskylän seutu (Linkki)")
+            identifier: "jyvaskyla"
             apiName: "waltti"
             boundarycirclelat: 62.243
             boundarycirclelon: 25.747
         }
         ListElement {
-            text: QT_TR_NOOP("Kajaani")
+            name: QT_TR_NOOP("Kajaanin seutu")
+            identifier: "kajaani"
             apiName: "waltti"
             boundarycirclelat: 64.227
             boundarycirclelon: 27.729
         }
         ListElement {
-            text: QT_TR_NOOP("Kotka")
+            name: QT_TR_NOOP("Kotkan seutu")
+            identifier: "kotka"
             apiName: "waltti"
             boundarycirclelat: 60.461
             boundarycirclelon: 26.939
         }
         ListElement {
-            text: QT_TR_NOOP("Kouvola")
+            name: QT_TR_NOOP("Kouvola")
+            identifier: "kouvola"
             apiName: "waltti"
             boundarycirclelat: 60.869
             boundarycirclelon: 26.700
         }
         ListElement {
-            text: QT_TR_NOOP("Kuopio")
+            name: QT_TR_NOOP("Kuopion seutu (Vilkku)")
+            identifier: "kuopio"
             apiName: "waltti"
             boundarycirclelat: 62.892
             boundarycirclelon: 27.678
         }
         ListElement {
-            text: QT_TR_NOOP("Lahti")
+            name: QT_TR_NOOP("Lahden seutu (LSL)")
+            identifier: "lahti"
             apiName: "waltti"
             boundarycirclelat: 60.984
             boundarycirclelon: 25.656
         }
         ListElement {
-            text: QT_TR_NOOP("Lappeenranta")
+            name: QT_TR_NOOP("Lappeenranta")
+            identifier: "lappeenranta"
             apiName: "waltti"
             boundarycirclelat: 61.056
             boundarycirclelon: 28.185
         }
         ListElement {
-            text: QT_TR_NOOP("Mikkeli")
+            name: QT_TR_NOOP("Mikkeli")
+            identifier: "mikkeli"
             apiName: "waltti"
             boundarycirclelat: 61.688
             boundarycirclelon: 27.274
         }
         ListElement {
-            text: QT_TR_NOOP("Oulu")
+            name: QT_TR_NOOP("Oulun seutu")
+            identifier: "oulu"
             apiName: "waltti"
             boundarycirclelat: 65.012
             boundarycirclelon: 25.471
         }
         ListElement {
-            text: QT_TR_NOOP("Rovaniemi")
+            name: QT_TR_NOOP("Rovaniemi (Linkkari)")
+            identifier: "rovaniemi"
             apiName: "waltti"
             boundarycirclelat: 66.500
             boundarycirclelon: 25.714
         }
         ListElement {
-            text: QT_TR_NOOP("Vaasa")
+            name: QT_TR_NOOP("Vaasa")
+            identifier: "vaasa"
             apiName: "waltti"
             boundarycirclelat: 63.096
             boundarycirclelon: 21.616
@@ -154,7 +171,7 @@ ApplicationWindow {
             var apiName = Storage.getSetting('api');
             for (var i = 0; i < regions.count; i++) {
                 var value = regions.get(i);
-                if (apiName === value.text.toLowerCase()) {
+                if (apiName === value.identifier) {
                     return value;
                 }
             }

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -44,10 +44,6 @@ ApplicationWindow {
         id: regions
 
         ListElement {
-            name: QT_TR_NOOP("Finland")
-            apiName: "finland"
-        }
-        ListElement {
             name: QT_TR_NOOP("Helsinki and the capital region (HRT)")
             identifier: "helsinki"
             apiName: "hsl"
@@ -165,6 +161,11 @@ ApplicationWindow {
             apiName: "waltti"
             boundarycirclelat: 63.096
             boundarycirclelon: 21.616
+        }
+        ListElement {
+            name: QT_TR_NOOP("Whole Finland")
+            identifier: "finland"
+            apiName: "finland"
         }
 
         function getRegion() {

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -173,13 +173,8 @@ ApplicationWindow {
 
         var apiValue = Storage.getSetting("api")
         if (apiValue === "Unknown") {
-            var dialog = pageStack.push(Qt.resolvedUrl("pages/StartupDialog.qml"))
-            dialog.onAccepted.connect(function() {
-                mainPage = pageStack.replace(Qt.resolvedUrl("pages/MainPage.qml"))
-            })
-            dialog.onRejected.connect(function() {
-                mainPage = pageStack.replace(Qt.resolvedUrl("pages/MainPage.qml"))
-            })
+            mainPage = pageStack.push(Qt.resolvedUrl("pages/MainPage.qml"), {}, true)
+            var dialog = pageStack.push(Qt.resolvedUrl("pages/StartupDialog.qml"), {}, true)
         }
         else {
             mainPage = pageStack.push(Qt.resolvedUrl("pages/MainPage.qml"))

--- a/qml/pages/ResultPage.qml
+++ b/qml/pages/ResultPage.qml
@@ -43,7 +43,7 @@ Page {
     function startSearch() {
         appWindow.itinerariesModel.clear()
         Reittiopas.get_route(search_parameters, appWindow.itinerariesModel,
-                             appWindow.itinerariesJson, Storage.getSetting('api'));
+                             appWindow.itinerariesJson, regions.getRegion());
     }
 
     function setCoverData() {

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -92,7 +92,7 @@ Page {
             ComboBox {
                 id: currentApi
                 function set_value(value) {
-                    var val = {"helsinki": 0, "tampere": 1, "turku": 2}[value]
+                    var val = {"helsinki": 0, "tampere": 1, "turku": 2, "hameenlinna": 3}[value]
                     currentApi.currentIndex = val
                 }
 
@@ -121,6 +121,15 @@ Page {
                         onClicked: {
                             Storage.setSetting("api","turku")
                             appWindow.currentApi = "turku"
+                            appWindow.coverContents = text
+                            appWindow.mainPage.refreshFavoriteRoutes()
+                        }
+                    }
+                    MenuItem {
+                       text: "Hämeenlinna"
+                        onClicked: {
+                            Storage.setSetting("api","hameenlinna")
+                            appWindow.currentApi = "hameenlinna"
                             appWindow.coverContents = text
                             appWindow.mainPage.refreshFavoriteRoutes()
                         }

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -93,14 +93,14 @@ Page {
                 id: currentApi
                 function set_value(value) {
                     for(var i = 0; i < regions.count; ++i) {
-                        if (regions.get(i).text.toLowerCase() === value) {
+                        if (regions.get(i).identifier === value) {
                             currentApi.currentIndex = i;
                             break;
                         }
                     }
                 }
 
-                label: qsTr("Active Region")
+                label: qsTr("Active region")
                 menu: ContextMenu {
                     id: regionMenu
 
@@ -115,8 +115,8 @@ Page {
                         model: regions
 
                         delegate: MenuItem {
-                            text: qsTr(model.text)
-                            property string value: model.text.toLowerCase()
+                            text: qsTr(model.name)
+                            property string value: model.identifier
                             onClicked: regionMenu.set_value(text, value)
                         }
                     }

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -115,7 +115,7 @@ Page {
                         model: regions
 
                         delegate: MenuItem {
-                            text: qsTr(model.name)
+                            text: qsTranslate("main", model.name)
                             property string value: model.identifier
                             onClicked: regionMenu.set_value(text, value)
                         }

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -92,46 +92,32 @@ Page {
             ComboBox {
                 id: currentApi
                 function set_value(value) {
-                    var val = {"helsinki": 0, "tampere": 1, "turku": 2, "hameenlinna": 3}[value]
-                    currentApi.currentIndex = val
+                    for(var i = 0; i < regions.count; ++i) {
+                        if (regions.get(i).text.toLowerCase() === value) {
+                            currentApi.currentIndex = i;
+                            break;
+                        }
+                    }
                 }
 
                 label: qsTr("Active Region")
                 menu: ContextMenu {
-                    MenuItem {
-                        text: "Helsinki"
-                        onClicked: {
-                            Storage.setSetting("api","helsinki")
-                            appWindow.currentApi = "helsinki"
-                            appWindow.coverContents = text
-                            appWindow.mainPage.refreshFavoriteRoutes()
-                        }
+                    id: regionMenu
+
+                    function set_value(text, value) {
+                        Storage.setSetting("api", value)
+                        appWindow.currentApi = value
+                        appWindow.coverContents = text
+                        appWindow.mainPage.refreshFavoriteRoutes()
                     }
-                    MenuItem {
-                       text: "Tampere"
-                        onClicked: {
-                            Storage.setSetting("api","tampere")
-                            appWindow.currentApi = "tampere"
-                            appWindow.coverContents = text
-                            appWindow.mainPage.refreshFavoriteRoutes()
-                        }
-                    }
-                    MenuItem {
-                       text: "Turku"
-                        onClicked: {
-                            Storage.setSetting("api","turku")
-                            appWindow.currentApi = "turku"
-                            appWindow.coverContents = text
-                            appWindow.mainPage.refreshFavoriteRoutes()
-                        }
-                    }
-                    MenuItem {
-                       text: "Hämeenlinna"
-                        onClicked: {
-                            Storage.setSetting("api","hameenlinna")
-                            appWindow.currentApi = "hameenlinna"
-                            appWindow.coverContents = text
-                            appWindow.mainPage.refreshFavoriteRoutes()
+
+                    Repeater {
+                        model: regions
+
+                        delegate: MenuItem {
+                            text: qsTr(model.text)
+                            property string value: model.text.toLowerCase()
+                            onClicked: regionMenu.set_value(text, value)
                         }
                     }
                 }

--- a/qml/pages/StartupDialog.qml
+++ b/qml/pages/StartupDialog.qml
@@ -49,6 +49,7 @@ Dialog {
                 MenuItem { text: "Helsinki" }
                 MenuItem { text: "Tampere" }
                 MenuItem { text: "Turku" }
+                MenuItem { text: "Hämeenlinna" }
             }
         }
     }
@@ -62,6 +63,9 @@ Dialog {
         }
         else if (region.currentIndex === 2) {
             Storage.setSetting('api', "turku")
+        }
+        else if (region.currentIndex === 3) {
+            Storage.setSetting('api', "hameenlinna")
         }
     }
 }

--- a/qml/pages/StartupDialog.qml
+++ b/qml/pages/StartupDialog.qml
@@ -52,8 +52,8 @@ Dialog {
                         model: regions
 
                         delegate: MenuItem {
-                            text: qsTr(model.text)
-                            property string value: model.text.toLowerCase()
+                            text: qsTr(model.name)
+                            property string value: model.identifier
                         }
                     }
                 }

--- a/qml/pages/StartupDialog.qml
+++ b/qml/pages/StartupDialog.qml
@@ -35,37 +35,32 @@ import "../js/storage.js" as Storage
 import "../components"
 
 Dialog {
-    Column {
+    SilicaFlickable {
         anchors.fill: parent
+        Column {
+            anchors.fill: parent
 
-        DialogHeader {
-            acceptText: defaultAcceptText
-        }
+            DialogHeader {
+                acceptText: defaultAcceptText
+            }
 
-        ComboBox {
-            id: region
-            label: qsTr("Choose region")
-            menu: ContextMenu {
-                MenuItem { text: "Helsinki" }
-                MenuItem { text: "Tampere" }
-                MenuItem { text: "Turku" }
-                MenuItem { text: "Hämeenlinna" }
+            ComboBox {
+                id: region
+                label: qsTr("Choose region")
+                menu: ContextMenu {
+                    Repeater {
+                        model: regions
+
+                        delegate: MenuItem {
+                            text: qsTr(model.text)
+                            property string value: model.text.toLowerCase()
+                        }
+                    }
+                }
             }
         }
     }
-
     onAccepted: {
-        if (region.currentIndex === 0) {
-            Storage.setSetting('api', "helsinki")
-        }
-        else if (region.currentIndex === 1) {
-            Storage.setSetting('api', "tampere")
-        }
-        else if (region.currentIndex === 2) {
-            Storage.setSetting('api', "turku")
-        }
-        else if (region.currentIndex === 3) {
-            Storage.setSetting('api', "hameenlinna")
-        }
+        Storage.setSetting('api', region.currentItem.value);
     }
 }

--- a/qml/pages/StartupDialog.qml
+++ b/qml/pages/StartupDialog.qml
@@ -52,7 +52,7 @@ Dialog {
                         model: regions
 
                         delegate: MenuItem {
-                            text: qsTr(model.name)
+                            text: qsTranslate("main", model.name)
                             property string value: model.identifier
                         }
                     }

--- a/rpm/harbour-jollaopas.yaml
+++ b/rpm/harbour-jollaopas.yaml
@@ -7,7 +7,7 @@ URL: http://hsarkanen.github.io/JollaOpas/
 License: "GPLv3"
 Sources:
 - '%{name}-%{version}.tar.bz2'
-Description: "Journey planner for Helsinki, Tampere & Turku area - based on Meegopas."
+Description: "Journey planner for Finnish mass transit regions providing Digitransit API - based on Meegopas."
 Configure: none
 Builder: qtc5
 QMakeOptions:


### PR DESCRIPTION
***Edit:* I changed the PR to cover a more thorough refactoring of the region system and to add all Waltti regions.**

This adds support for Hämeenlinna addresses (search range) and uses the Waltti Digitransit API.

Using the same API we can access also the following just by changing the search range:
* Joensuu
* Jyväskylä
* Kajaani
* Kotka
* Kouvola
* Kuopio
* Lahti
* Lappeenranta
* Mikkeli
* Oulu
* Rovaniemi
* Salo
* Vaasa

Additionally Digitransit has the Finland API, which covers all of them, so it might be useful to additionally have one region option that doesn't restrict the address search at all.

Do you have some plans / insight on what should be done to add the rest of the locations to the application?