### PR TITLE
Make search interval configurable

### DIFF
--- a/localization/fi.ts
+++ b/localization/fi.ts
@@ -298,8 +298,8 @@
     <name>ResultPage</name>
     <message>
         <location filename="../qml/pages/ResultPage.qml" line="104"/>
-        <source>Next</source>
-        <translation>Seuraavat</translation>
+        <source>Next (+%1 min)</source>
+        <translation>Seuraavat (+%1 min)</translation>
     </message>
     <message>
         <location filename="../qml/pages/ResultPage.qml" line="126"/>
@@ -313,8 +313,8 @@
     </message>
     <message>
         <location filename="../qml/pages/ResultPage.qml" line="154"/>
-        <source>Previous</source>
-        <translation>Edelliset</translation>
+        <source>Previous (-%1 min)</source>
+        <translation>Edelliset (-%1 min)</translation>
     </message>
     <message>
         <location filename="../qml/pages/ResultPage.qml" line="167"/>
@@ -425,7 +425,7 @@
     <message>
         <location filename="../qml/pages/SettingsPage.qml" line="132"/>
         <source>Route search parameters</source>
-        <translation>Reitinhaku parametrit</translation>
+        <translation>Reittihaku</translation>
     </message>
     <message>
         <location filename="../qml/pages/SettingsPage.qml" line="139"/>

--- a/qml/pages/ResultPage.qml
+++ b/qml/pages/ResultPage.qml
@@ -93,7 +93,7 @@ Page {
                 /* workaround to modify qml array is to make a copy of it,
                    modify the copy and assign the copy back to the original */
                 var new_parameters = search_parameters
-                new_parameters.jstime.setMinutes(new_parameters.jstime.getMinutes() + 15)
+                new_parameters.jstime.setMinutes(new_parameters.jstime.getMinutes() + Storage.getSetting("search_interval"))
                 new_parameters.time = Qt.formatTime(new_parameters.jstime.getMinutes(), "hhmm")
                 search_parameters = new_parameters
 
@@ -101,7 +101,7 @@ Page {
             }
 
             Label {
-                text: qsTr("Next") + " (+15 min)"
+                text: qsTr("Next (+%1 min)").arg(Math.floor(Storage.getSetting("search_interval")))
                 width: parent.width
                 horizontalAlignment: Text.AlignHCenter
                 anchors.verticalCenter: parent.verticalCenter
@@ -151,7 +151,7 @@ Page {
                 }
 
                 Label {
-                    text: qsTr("Previous") + " (-15 min)"
+                    text: qsTr("Previous (-%1 min)").arg(Math.floor(Storage.getSetting("search_interval")))
                     width: parent.width
                     horizontalAlignment: Text.AlignHCenter
                     anchors.verticalCenter: parent.verticalCenter

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -67,6 +67,8 @@ Page {
             changeReluctance.set_value(setting == "Unknown"?"10" : Math.floor(setting))
             setting = Storage.getSetting("walk_reluctance")
             walkReluctance.set_value(setting == "Unknown"?"2" : Math.floor(setting))
+            setting = Storage.getSetting("search_interval")
+            searchInterval.set_value(setting == "Unknown" ? "15" : Math.floor(setting))
             setting = Storage.getSetting("default_zoom_level")
             defaultZoomLevel.set_value(setting == "Unknown"?"5" : Math.floor(setting))
             setting = Storage.getSetting("search_button_disabled")
@@ -129,7 +131,7 @@ Page {
             }
 
             SectionHeader {
-                text: qsTr("Route search parameters")
+                text: qsTr("Route search")
             }
             TextSwitch {
                 id: busSwitch
@@ -330,6 +332,27 @@ Page {
                         text: qsTr("Running 150 m/min")
                         onClicked: Storage.setSetting('walking_speed','150')
                     }
+                }
+            }
+
+            Slider {
+                id: searchInterval
+                function set_value(value) {
+                    searchInterval.value = value
+                    searchInterval.updateLabel()
+                }
+                function updateLabel() {
+                    searchInterval.label = qsTr("Search interval") + " (" + searchInterval.value + ")"
+                }
+                width: parent.width
+                minimumValue: 5
+                maximumValue: 120
+                value: 15
+                stepSize: 1
+                handleVisible: true
+                onValueChanged: {
+                    Storage.setSetting("search_interval", searchInterval.value)
+                    searchInterval.updateLabel()
                 }
             }
 


### PR DESCRIPTION
Makes search interval configurable, but defaults to 15 minutes as before. This is useful in regions with less frequent public transport to find the next available route more easily.