### PR TITLE
Fix a type bug causing at least warnings in handling route API response

### DIFF
--- a/qml/js/reittiopas.js
+++ b/qml/js/reittiopas.js
@@ -167,8 +167,8 @@ function get_route(parameters, itineraries_model, itineraries_json, api_type) {
                 output.duration = Math.round(route.duration/60)
                 output.start = new Date(route.startTime)
                 output.finish = new Date(route.endTime)
-                output.first_transport = 0
-                output.last_transport = 0
+                output.first_transport = null
+                output.last_transport = null
                 output.walk = route.walkDistance
                 output.legs = []
                 for (var leg in route.legs) {


### PR DESCRIPTION
This caused a type error since the variable is later replaced with a Date object. Seems to work properly when initialising with null instead.