### PR TITLE
Show from and to stops in stop listing

### DIFF
--- a/qml/pages/StopPage.qml
+++ b/qml/pages/StopPage.qml
@@ -59,13 +59,29 @@ Page {
 
     function dumpStops(index, model) {
         var legdata = appWindow.itinerariesModel.get(appWindow.itinerariesIndex).legs.get(index)
+        var stop = {
+            "name" : legdata.from.name,
+            "shortCode" : legdata.from.shortCode,
+            "latitude" : legdata.from.latitude,
+            "longitude" : legdata.from.longitude,
+            "arrTime" : 0,
+            "depTime" : 0,
+            "time_diff": 0
+        }
+        model.append(stop)
         var countOfLocations = legdata.locs.count;
         for (var locindex = 0; locindex < countOfLocations; ++locindex) {
             var locdata =  legdata.locs.get(locindex)
             model.append(locdata)
+        }
+        stop.name = legdata.to.name
+        stop.shortCode = legdata.to.shortCode
+        stop.latitude = legdata.to.latitude
+        stop.longitude = legdata.to.longitude
+        model.append(stop)
+
+        model.done = true
     }
-    model.done = true
-}
 
 /*
 // TODO:


### PR DESCRIPTION
Adding the from and to stops to the stop page. This causes walking legs to also show stops and maps and causes less confusion for example due to legs with only one intermediate stop.